### PR TITLE
Hide Menu descriptions in store-core, store-refund.  store-shop update for hiding descriptions

### DIFF
--- a/configs/store/core.cfg
+++ b/configs/store/core.cfg
@@ -4,4 +4,5 @@
 	"mainmenu_commands"			"!store /store"
 	"credits_commands"			"!credits /credits"
 	"first_connection_credits"	"0"
+	"hide_menu_descriptions"	"0"
 }

--- a/configs/store/refund.cfg
+++ b/configs/store/refund.cfg
@@ -2,4 +2,5 @@
 {
     "refund_commands"			"!refund /refund !sell /sell"
 	"refund_price_percentage"	"0.5"
+	"hide_menu_descriptions"	"1"
 }

--- a/scripting/store-core.sp
+++ b/scripting/store-core.sp
@@ -43,6 +43,8 @@ new bool:g_allPluginsLoaded = false;
 new Handle:g_hOnChatCommandForward;
 new Handle:g_hOnChatCommandPostForward;
 
+new bool:g_hideMenuItemDescriptions = false;
+
 /**
  * Called before plugin is loaded.
  * 
@@ -286,6 +288,8 @@ LoadConfig()
 	Store_RegisterChatCommands(buffer, ChatCommand_Credits);
 
 	g_firstConnectionCredits = KvGetNum(kv, "first_connection_credits");
+	
+	g_hideMenuItemDescriptions = bool:KvGetNum(kv, "hide_menu_descriptions", 0);
 
 	CloseHandle(kv);
 }
@@ -374,7 +378,11 @@ public OnGetCreditsComplete(credits, any:serial)
 	for (new item = 0; item < g_menuItemCount; item++)
 	{
 		decl String:text[255];  
-		Format(text, sizeof(text), "%T\n%T", g_menuItems[item][MenuItemDisplayName], client, g_menuItems[item][MenuItemDescription], client);
+		if(g_hideMenuItemDescriptions == false){
+			Format(text, sizeof(text), "%T\n%T", g_menuItems[item][MenuItemDisplayName], client, g_menuItems[item][MenuItemDescription], client);
+		} else {
+			Format(text, sizeof(text), "%T", g_menuItems[item][MenuItemDisplayName], client);
+		}
 				
 		AddMenuItem(menu, g_menuItems[item][MenuItemValue], text);
 	}

--- a/scripting/store-refund.sp
+++ b/scripting/store-refund.sp
@@ -117,7 +117,7 @@ public GetCategoriesCallback(ids[], count, any:serial)
 
 
 		decl String:itemText[sizeof(displayName) + 1 + sizeof(description)];
-		if(g_hideCategoryDescriptions==false){
+		if(g_hideMenuItemDescriptions==false){
 			Store_GetCategoryDescription(ids[category], description, sizeof(description));
 			Format(itemText, sizeof(itemText), "%s\n%s", displayName, description);
 		} else {

--- a/scripting/store-refund.sp
+++ b/scripting/store-refund.sp
@@ -11,6 +11,7 @@ new String:g_currencyName[64];
 
 new Float:g_refundPricePercentage;
 new bool:g_confirmItemRefund = true;
+new bool:g_hideMenuItemDescriptions = false;
 
 public Plugin:myinfo =
 {
@@ -64,6 +65,7 @@ LoadConfig()
 	
 	g_refundPricePercentage = KvGetFloat(kv, "refund_price_percentage", 0.5);
 	g_confirmItemRefund = bool:KvGetNum(kv, "confirm_item_refund", 1);
+	g_hideMenuItemDescriptions = bool:KvGetNum(kv, "hide_menu_descriptions", 0);
 
 	CloseHandle(kv);
 }
@@ -112,10 +114,15 @@ public GetCategoriesCallback(ids[], count, any:serial)
 		Store_GetCategoryDisplayName(ids[category], displayName, sizeof(displayName));
 
 		decl String:description[STORE_MAX_DESCRIPTION_LENGTH];
-		Store_GetCategoryDescription(ids[category], description, sizeof(description));
+
 
 		decl String:itemText[sizeof(displayName) + 1 + sizeof(description)];
-		Format(itemText, sizeof(itemText), "%s\n%s", displayName, description);
+		if(g_hideCategoryDescriptions==false){
+			Store_GetCategoryDescription(ids[category], description, sizeof(description));
+			Format(itemText, sizeof(itemText), "%s\n%s", displayName, description);
+		} else {
+			Format(itemText, sizeof(itemText), "%s", displayName);
+		}
 		
 		decl String:itemValue[8];
 		IntToString(ids[category], itemValue, sizeof(itemValue));

--- a/scripting/store-shop.sp
+++ b/scripting/store-shop.sp
@@ -279,13 +279,17 @@ public GetItemsCallback(ids[], count, any:pack)
 	for (new item = 0; item < count; item++)
 	{		
 		decl String:displayName[64];
-		Store_GetItemDisplayName(ids[item], displayName, sizeof(displayName));
-		
 		decl String:description[128];
-		Store_GetItemDescription(ids[item], description, sizeof(description));
-	
-		decl String:text[sizeof(displayName) + sizeof(description) + 5];
-		Format(text, sizeof(text), "%s [%d %s]\n%s", displayName, Store_GetItemPrice(ids[item]), g_currencyName, description);
+		decl String:text[sizeof(displayName) + sizeof(description) + 5];		
+
+		Store_GetItemDisplayName(ids[item], displayName, sizeof(displayName));
+
+		if(g_hideCategoryDescriptions==false){
+			Store_GetItemDescription(ids[item], description, sizeof(description));
+			Format(text, sizeof(text), "%s [%d %s]\n%s", displayName, Store_GetItemPrice(ids[item]), g_currencyName, description);
+		} else {
+			Format(text, sizeof(text), "%s [%d %s]", displayName, Store_GetItemPrice(ids[item]), g_currencyName);
+		}
 		
 		decl String:value[8];
 		IntToString(ids[item], value, sizeof(value));


### PR DESCRIPTION
This merge contains the following changes:
- Add "hide_menu_descriptions" config for store-core and store-refund (hl2:dm menus aren't tall enough for both name and description)
- Makes store-shop honor g_hideCategoryDescriptions in GetItemsCallBack

Thanks

[foo] bar
