### PR TITLE
Fix and point out several handle leaks

### DIFF
--- a/scripting/include/store/store-backend.inc
+++ b/scripting/include/store/store-backend.inc
@@ -525,7 +525,7 @@ native Store_GetLoadoutTeam(id);
  * To determine how many items the player has of the same name, the callback provides the
  * itemCount[] array.
  *
- * To deremine whether or not an item is equipped in the loadout specified, the callback
+ * To determine whether or not an item is equipped in the loadout specified, the callback
  * provides the equipped[] array.
  *
  * For example:
@@ -720,7 +720,7 @@ native Store_SetItemEquippedState(accountId, itemId, loadoutId, bool:isEquipped,
  * To determine how many items the player has of the same name, the callback provides the
  * itemCount[] array.
  *
- * To deremine whether or not an item is equipped in the loadout specified, the callback
+ * To determine whether or not an item is equipped in the loadout specified, the callback
  * provides the equipped[] array.
  *
  * For example:

--- a/scripting/store-gifting.sp
+++ b/scripting/store-gifting.sp
@@ -215,6 +215,7 @@ public DropGetCreditsCallback(credits, any:pack)
 	}
 	else
 	{
+		CloseHandle(pack);
 		PrintToChat(client, "%s%t", STORE_PREFIX, "Not enough credits", g_currencyName);
 	}
 }
@@ -891,7 +892,8 @@ GiftCredits(from, to, amount)
 
 public TakeCreditsCallback(accountId, any:pack)
 {
-	SetPackPosition(pack, 8);
+	ResetPack(pack);
+	ReadPackCell(pack); // from
 
 	new to = ReadPackCell(pack);
 	new amount = ReadPackCell(pack);
@@ -931,7 +933,8 @@ GiftItem(from, to, itemId)
 
 public RemoveUserItemCallback(accountId, itemId, any:pack)
 {
-	SetPackPosition(pack, 8);
+	ResetPack(pack);
+	ReadPackCell(pack); // from
 
 	new to = ReadPackCell(pack);
 
@@ -1025,6 +1028,7 @@ public PickupGiveCallback(accountId, any:pack)
 	decl String:itemType[32];
 	ReadPackString(pack, itemType, sizeof(itemType));
 	new value = ReadPackCell(pack);
+	CloseHandle(pack);
 
 	if (StrEqual(itemType, "credits"))
 	{

--- a/scripting/store-inventory.sp
+++ b/scripting/store-inventory.sp
@@ -144,8 +144,9 @@ public Action:Command_PrintItemTypes(client, args)
 		
 		ResetPack(itemType);
 		new Handle:plugin = Handle:ReadPackCell(itemType);
-
-		SetPackPosition(itemType, 24);
+		ReadPackCell(itemType); // useCallback
+		ReadPackCell(itemType); // attrsCallback
+		
 		decl String:typeName[32];
 		ReadPackString(itemType, typeName, sizeof(typeName));
 
@@ -187,6 +188,7 @@ public GetCategoriesCallback(ids[], count, any:serial)
 	if (client == 0)
 		return;
 	
+	// FIXME: If one of the GetUserItems queries fails, this menu handle leaks.
 	categories_menu[client] = CreateMenu(InventoryMenuSelectHandle);
 	SetMenuTitle(categories_menu[client], "%T\n \n", "Inventory", client);
 		
@@ -588,8 +590,7 @@ public Native_CallItemAttrsCallback(Handle:plugin, params)
 	ResetPack(pack);
 
 	new Handle:callbackPlugin = Handle:ReadPackCell(pack);
-	
-	SetPackPosition(pack, 16);
+	ReadPackCell(pack); // useCallback
 
 	new callback = ReadPackCell(pack);
 

--- a/scripting/store-shop.sp
+++ b/scripting/store-shop.sp
@@ -169,6 +169,7 @@ public GetCategoriesCallback(ids[], count, any:serial)
 	if (client == 0)
 		return;
 	
+	// FIXME: If one of the GetUserItems queries fails, this menu handle leaks.
 	categories_menu[client] = CreateMenu(ShopMenuSelectHandle);
 	SetMenuTitle(categories_menu[client], "%T\n \n", "Shop", client);
 	


### PR DESCRIPTION
The store-backend was unloaded due to lots of open handles.
L 12/26/2014 - 18:46:06: [SM] MEMORY LEAK DETECTED IN PLUGIN (file "store\store-backend.smx")
L 12/26/2014 - 18:46:06: [SM] Unloading plugin to free 14756 handles.
L 12/26/2014 - 18:46:06: [SM] Contact the author(s) of this plugin to correct this error.
L 12/26/2014 - 18:46:06: --------------------------------------------------------------------------
L 12/26/2014 - 18:46:06: TypeIDatabase           |Count7413
L 12/26/2014 - 18:46:06: TypeDataPack            |Count7340
L 12/26/2014 - 18:46:06: TypeGlobalFwd           |Count3
L 12/26/2014 - 18:46:06: -- Approximately 96 bytes of memory are in use by (14756) Handles.

I doubt the fixes in this PR really avoid all the leaks. I've pointed out several places in the code which still leak handles but require changes to the API. The backend callbacks should really be called when the query failed too. With some "success" boolean set to false or 0 data being returned.

All the plugins that use the backend and pass a handle through the any:data callback leak that handle if the query of the method in question fails.

All the open IDatabase handles are threaded queries. A possible cause could be the database connection going away and the plugin firing far too many queries. The DBI system can't process them fast enough, so they stack up. Maybe add some more caching or use the cache more often?
